### PR TITLE
feat: improve navigation ui / ux

### DIFF
--- a/docs/css/tacc-docs.css
+++ b/docs/css/tacc-docs.css
@@ -167,9 +167,8 @@ svg.logo [fill]:not([fill="none"]) {
 
 
 
-/* To style open/close buttons */
+/* To position open/close buttons */
 /* To make whole link clickable, not just button */
-/* To prevent open/close buttons dynamic arrival from moving text */
 
 .wy-menu-vertical {
   --button-width: 1ch; /* estimate, based on icon (e.g. ▾, ▸) */
@@ -179,7 +178,10 @@ svg.logo [fill]:not([fill="none"]) {
 .wy-menu-vertical li a {
   position: relative; /* support `position: absolute` child */
 }
-.wy-menu-vertical li a button.toctree-expand {
+.wy-menu-vertical li:not(.has-list) a button.toctree-expand {
+  display: none;
+}
+.wy-menu-vertical li.has-list a button.toctree-expand {
   margin-left: unset; /* undo theme.css */
 
   /* To expand button over entire link */
@@ -189,6 +191,11 @@ svg.logo [fill]:not([fill="none"]) {
   padding: var(--link-pad-vert) var(--link-pad-horz);
   width: 100%;
   text-align: left; /* to prevent width: 100% from moving ::before to center */
+}
+.wy-menu-vertical li button.toctree-expand:before {
+  /* To move button icon */
+  text-indent: calc( -1 * var(--link-pad-horz) ); /* leftward, outside text */
+  height: 100%; /* upward, inline with first line of mult-line text */
 }
 
 
@@ -262,11 +269,6 @@ svg.logo [fill]:not([fill="none"]) {
 
 /* To change icons */
 
-/* To reposition icon */
-.wy-menu-vertical li button.toctree-expand:before {
-  text-indent: calc( -1 * var(--link-pad-horz) ); /* leftward, outside text */
-  height: 100%; /* upward, inline with first line of mult-line text */
-}
 .wy-menu-vertical li:not(.on, .current) button.toctree-expand:before {
   content: "\f0da";
 }

--- a/docs/js/modules/addNavClasses.js
+++ b/docs/js/modules/addNavClasses.js
@@ -1,0 +1,4 @@
+/* To add class for nav items that have sub-navs */
+$('.wy-menu-vertical li:has(li)').each(function() { 
+  this.classList.add('has-list');
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ extra_javascript:
     - js/modules/styleLinksOutsideMainContent.js
     - js/modules/swapImgSvgWithRawSvg.js
     - js/modules/removeThemeClasses.js
+    - js/modules/addNavClasses.js
 
 nav:
   - TACC Basics :


### PR DESCRIPTION
## Overview

Do not hide sub-nav's. Move nav open/close triangles to outside each list.

## Related

None.

## Changes

- **changed** `tacc-docs.css` sub-nav open/close logic
- **removed** `tacc-docs.css` sub-nav "open/close triangle inside list" styles
- **added** `docs/js/modules/addNavClasses.js` which makes conditional styling easier
- **added** theme config `collapse_navigation: false`

## Testing

1. Nav links with children _always_ show open/close triangle.
2. Nav links with **no** children _never_ show open/close triangle.
3. Clicking nav links with children opens/closes list.
    - Test a nav item that is only one line tall.
    - Test a nav item that is only two lines tall (and click bottom line).
4. Clicking nav links with **no** children loads page.
5. Re-test on Firefox (which does not support `:has()` selector).
6. Test with JavaScript disabled:
    - verify no open/close triangles
    - verify links work, nested and not, with and without sub-nav

## UI

https://user-images.githubusercontent.com/62723358/229937760-8c563db7-b3b3-43e6-925a-a7cd39fec3d3.mov

https://user-images.githubusercontent.com/62723358/229937765-c4047787-1a64-44c2-9b99-fbc1b6f11f5a.mov