### PR TITLE
feat: push docker image tagged with software version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           if [ -z "$EVENT_SHA" ]; then SHORT_SHA=${GITHUB_SHA::8}; else SHORT_SHA=${EVENT_SHA::8}; fi
           echo ::set-output name=sha_short::${SHORT_SHA}
           VERSION=$(git describe --exact-match --tags 2>/dev/null || true)
-          if [ -n "$VERSION" ]; then VERSION="noversion"; fi
+          if [ -z "$VERSION" ]; then VERSION="noversion"; fi
           echo ::set-output name=version::${VERSION}
           BRANCH_SHORT=`git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g'`
           echo ::set-output name=branch_short::${BRANCH_SHORT}


### PR DESCRIPTION
## Overview

Push a docker iamge whose tag is the software version.

## Related

None

## Changes

- **added** "version" to github build workflow

## Testing

### Proof-of-Concept

```sh
$ git describe --tags
v0.2.0-2-g5eefb644
(3.11) 

$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
(3.11) 

$ git describe --tags
v0.2.0
(3.11) 
```

### Run Job

1. Open https://github.com/TACC/TACC-Docs/actions/workflows/build.yml
2. Run workflow for branch `feat/push-docker-image-tagged-with-version`.
3. Open build log.
4. **Verify success and version is `taccwma/tacc-docs:noversion`.**
5. Tag latest commit of this branch `test-pr-25`.
6. Run workflow for branch `feat/push-docker-image-tagged-with-version`.
7. Open build log.
8. **Verify success and version is `taccwma/tacc-docs:test-pr-25`.**
9. Delete tag `test-pr-25`.

## UI

### `taccwma/tacc-docs:noversion`

https://github.com/TACC/TACC-Docs/actions/runs/9182897771/job/25252580475

### `taccwma/tacc-docs:test-pr-25`

https://github.com/TACC/TACC-Docs/actions/runs/9182948032/job/25252710242