### PR TITLE
fix: tag conflict when pushing v0.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           if [ -z "$EVENT_SHA" ]; then SHORT_SHA=${GITHUB_SHA::8}; else SHORT_SHA=${EVENT_SHA::8}; fi
           echo ::set-output name=sha_short::${SHORT_SHA}
-          SHORT_REF=`git describe --exact-match --tags 2>/dev/null || git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g`
+          SHORT_REF=`git describe --exact-match --tags 2>/dev/null || git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g'`
           echo ::set-output name=ref_short::${SHORT_REF}
         env:
           EVENT_SHA: ${{ github.event.client_payload.sha }}


### PR DESCRIPTION
## Overview

Fix:

> Error: fatal: Cannot fetch both `<sha>` and refs/tags/`<tag>` to refs/tags/`<tag>`
> — https://github.com/TACC/TACC-Docs/actions/runs/9183034344/job/25252965529

## Related

* fixes #25
* borrows code from https://github.com/TACC/Core-CMS/pull/801

## Changes

* **removes** `fetch-tags` request
* **renames** `SHORTSHA` to `SHORT_SHA`
* **renames** `SHORT_BRANCH` to `SHORT_REF`

## Testing

1. Tag latest commit of this branch `test-pr-26`.
2. Open https://github.com/TACC/TACC-Docs/actions/workflows/build.yml
3. Run workflow for tag `test-pr-26`.
4. Open build log.
5. **Verify success and version is `taccwma/tacc-docs:test-pr-26`.**
6. Delete tag `test-pr-26`.

## UI

https://github.com/TACC/TACC-Docs/actions/runs/9183413738/job/25254079592