### PR TITLE
fix: accessible name for logo

### DIFF
--- a/themes/tacc-readthedocs/main.html
+++ b/themes/tacc-readthedocs/main.html
@@ -69,11 +69,27 @@
   {%- endblock %}
 
   {%- block site_name %}
-    {{ super() }}
+    {%- if config.theme.logo %}
+      {# TACC: #}{# To provide accessible text (in case <img> becomes <svg>) #}
+      {# FAQ: swapImgSvgWithRawSvg.js does not preserve `title` attribute #}
+      <a href="{{ nav.homepage.url|url }}" title="{{ config.site_name }} ({% trans %}Logo{% endtrans %})">
+      {# /TACC #}
+    {%- else %}
+      <a href="{{ nav.homepage.url|url }}" class="icon icon-home"> {{ config.site_name }}
+    {%- endif %}
+    {%- if config.theme.logo %}
+      {# TACC: #}{# To add site name to accessible text #}
+      <img src="{{ config.theme.logo|url }}" class="logo" alt="{{ config.site_name }} ({% trans %}Logo{% endtrans %})"/>
+      {# /TACC #}
+    {%- endif %}
+    </a>
+
+    {# TACC: #}{# To add a secondary name to the navigation #}
     {%- if config.theme.nav_name %}
     <h1 class="nav-name">{{ config.theme.nav_name }}</h1>
     {%- endif %}
     <a href="{{ config.theme.cms_url }}" class="cms-link">{{ config.theme.cms_name }}</a>
+    {# /TACC #}
   {%- endblock %}
 
   {%- block scripts %}


### PR DESCRIPTION
## Overview

Add accessible text name of site to link around logo image.

## Related

None.

## Changes

- __adds__ readthedocs theme main.html `site_name` block
- __adds__ `title` text for image link
- __changes__ `alt` text for image

## Testing

1. Open site.
2. Verify the `<a>` around the `<img>` (or `<svg>`) has a title attribute that matches `site_name`.

## UI

| before (with `<svg>`) | after (with `<svg>`) | after (with `<img>`) |
| - | - | - |
| ![before (wtih svg)](https://github.com/TACC/TACC-Docs/assets/62723358/8d8f48ad-8156-4c39-82ec-e4e2cebc676a) | ![after (with svg)](https://github.com/TACC/TACC-Docs/assets/62723358/e0198e3b-7bb6-4047-969f-053397e64b4c) | ![after (with png)](https://github.com/TACC/TACC-Docs/assets/62723358/650bb6d1-edd8-44c9-9825-e20217fc56ae) |