### PR TITLE
fix: img and svg logo padding should match

### DIFF
--- a/docs/css/core/tacc-docs.css
+++ b/docs/css/core/tacc-docs.css
@@ -90,7 +90,7 @@
 .wy-side-nav-search .wy-dropdown > a /*img*/.logo,
 .wy-side-nav-search > a /*img*/.logo {
   width: 100%;
-  padding: 5px; /* so svg padding matches img padding */
+  padding: unset;
 }
 
 


### PR DESCRIPTION
## Overview

Make sure and `<svg>` logo gets the same amount of padding as an `<img>`

## Related

None.

## Changes

- **changed** CSS

## Testing

1. Use `.svg` version of one logo.
2. Use `.png` version of same logo.
3. Verify size matches.

## UI

| before (png) | after (png) | svg |
| - | - | - |
| ![png (before)](https://github.com/TACC/TACC-Docs/assets/62723358/9c4a8bcd-a5c4-4cb1-a7c7-b0f90cadf0f6) | ![png (after)](https://github.com/TACC/TACC-Docs/assets/62723358/5cce1db6-2ece-4bde-a775-d1bce77c8aba) |  ![svg](https://github.com/TACC/TACC-Docs/assets/62723358/f7cdd509-7c9b-4b26-b58b-d6de85c3ef8c) |