### PR TITLE
feat: add `id="tacc-readthedocs"`

### DIFF
--- a/themes/tacc-readthedocs/main.html
+++ b/themes/tacc-readthedocs/main.html
@@ -92,6 +92,14 @@
     {# /TACC #}
   {%- endblock %}
 
+  {% block content %}
+    {# TACC: #}{# To wrap page with an id #}{# HELP: Add id to <html> instead #}
+    <div id="tacc-readthedocs">
+      {{ page.content }}
+    </div>
+    {# /TACC #}
+  {% endblock %}
+
   {%- block scripts %}
     <script>var base_url = '{{ base_url }}';</script>
     {# TACC: #}{# To provide specific config data to scripts #}


### PR DESCRIPTION
## Overview

Add `id="tacc-readthedocs"` around content, so clients can style dependent on whether theme is loaded.

> [!WARNING]
> Not ideal, because it adds another extra div **and** the id can't be used for navigation. _But when the theme override `tacc-readthedocs` become a full-fledged theme `tacc-core-docs`, then I can do it "the right way"._

## Related

- required by https://github.com/DesignSafe-CI/DS-User-Guide

## Changes

- **added** markup wrapper for content

## Testing

1. Verify content is wrapped in an `id="tacc-readthedocs"`.

## UI

| before | after |
| - | - |
| ![before](https://github.com/TACC/TACC-Docs/assets/62723358/a4efc908-7adc-45f9-8244-525547c20da2) | ![after](https://github.com/TACC/TACC-Docs/assets/62723358/af502ea1-4774-4ab0-86be-f9da4850c9ab) |