### PR TITLE
refactor: WI-157 from code to docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,5 @@ FROM python-base as production
 
 COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
 
-COPY . /code
-WORKDIR /code
+COPY . /docs
+WORKDIR /docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   docs:
     build: .
     volumes:
-      - .:/code
+      - .:/docs
     ports:
       - 127.0.0.1:8000:8000
-    command: ["mkdocs", "serve", "--dev-addr", "0.0.0.0:8000", "--watch-theme", "--config-file", "/code/mkdocs.yml"]
+    command: ["mkdocs", "serve", "--dev-addr", "0.0.0.0:8000", "--watch-theme", "--config-file", "/docs/mkdocs.yml"]
     container_name: tup_docs


### PR DESCRIPTION
## Overview

Move docker content from `/code` to `/docs`.

<details>

Deploying https://github.com/DesignSafe-CI/DS-User-Guide/pull/31 to prod is trouble if the content is in `/code` (new) instead of `/docs`. The change began in TACC/TACC-Docs, so I change it here first.

</details>

## Related

- [WI-157](https://jira.tacc.utexas.edu/browse/WI-157)
- required by …

## Changes

- **changed** docker content location from `/code` to `/docs`

## Testing

1. `make stop`
2. `make start`
3. `make build`
4. open https://localhost:8000
5. ✅ verify docs load

## UI

**Skipped.** The [staging docs](https://pprd.docs.tacc.utexas.edu/) loads after [deploy](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/388/) of [build](https://github.com/TACC/TACC-Docs/actions/runs/9422980602).