### PR TITLE
fix: extra space from empty current list in nav

### DIFF
--- a/docs/css/core/tacc-docs.css
+++ b/docs/css/core/tacc-docs.css
@@ -194,7 +194,7 @@ svg.logo [fill]:not([fill="none"]) {
   padding: var(--link-pad-vert) var(--link-pad-horz); /* overwrite theme.css */
 }
 .wy-menu-vertical li.on ul,
-.wy-menu-vertical li.current ul {
+.wy-menu-vertical li.current.has-list ul {
   padding-left: var(--link-pad-horz);
   padding-bottom: 10px;
 }


### PR DESCRIPTION
## Overview

Remove extra space from empty child lists in nav sidebar.

## Related

None

## Changes

- **changed** CSS selector

## Testing

1. Open http://0.0.0.0:8000/.
2. Verify less space between "Documentation Overview" and "Portal Access" than before.

## UI

| before | after |
| - | - |
| <img width="1275" alt="before" src="https://github.com/TACC/TACC-Docs/assets/62723358/6818c456-dd58-4c47-9365-2b58c8f9ebe3"> | <img width="1275" alt="after" src="https://github.com/TACC/TACC-Docs/assets/62723358/6d3feb0c-d37e-4145-8d22-ded46d55d8b7"> |