### PR TITLE
fix: permalink too low on wrapped heading

### DIFF
--- a/docs/css/core/tacc-docs.css
+++ b/docs/css/core/tacc-docs.css
@@ -653,6 +653,7 @@ pre.job-script code {
     --space: 0.5em;
     --offset: calc( 1ch + var(--space) );
 
+    top: 0;
     left: 0;
     padding-right: var(--space);
     translate: calc( -1 * var(--offset) );


### PR DESCRIPTION
## Overview

Permalink icon was aligned to bottom of heading instead of top.

## Related

- fixes #39

## Changes

- **added** a CSS rule

## Testing

1. Open a page with a heading that wraps.
2. Verify permalink icon is at top of heading (not bottom).

## UI

| before | after |
| - | - |
| <img width="820" alt="before" src="https://github.com/user-attachments/assets/63ffd19b-9b94-4a8e-acda-dbf7900c457f"> | <img width="820" alt="after" src="https://github.com/user-attachments/assets/a6772d37-26f1-4231-a36f-c37120292410"> |