### PR TITLE
fix: nav triangle clickable area too small

### DIFF
--- a/docs/css/core/tacc-docs.css
+++ b/docs/css/core/tacc-docs.css
@@ -170,7 +170,9 @@
     top: 0;
     left: 0;
     bottom: 0;
-    margin-inline: var(--button-margin);
+
+    box-sizing: content-box;
+    padding-inline: var(--button-margin);
     padding-block: var(--link-pad-vert);
     width: var(--button-width);
     text-align: center;


### PR DESCRIPTION
## Overview

The clickable area of a nav triangle is too small. Clicking out of it can cause click on text instead. The behavior of clicking triangle and clicking text can differ.

## Related

- noticed during test of https://github.com/TACC/TACC-Docs/pull/42

## Changes

- **changed** margin to padding
- **changed** box-sizing

## Testing

1. Click arrow.
2. See menu open/close.
3. Click left and right of arrow, but not on text.
4. ✅ See menu open/close.

## UI

> [!NOTE]
> See colored space around highlighted triangle. Orange area is not clickable for triangle. Green and Blue are clickable area for triangle.

| Before | After |
| - | - |
| <img width="1194" alt="clickable area before" src="https://github.com/user-attachments/assets/d06f7153-b662-486f-948d-b42d125fd51f"> | <img width="1194" alt="clickable area after" src="https://github.com/user-attachments/assets/5550dcdf-4af8-4a66-bd22-2774cd4ec32c"> |