### PR TITLE
fix: GH-23 support macos docker users

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,6 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          install: true
       -
         name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## Overview

Also build for `arm64` (e.g. macOS M1 and M2 chips).

## Related

- fixes GH-23

## Changes

> * Set up Docker Buildx: Added `install: true` to ensure Buildx is installed.
> * Specify Platforms: Added `platforms: linux/amd64,linux/arm64` to the `docker/build-push-action` step to build for both `amd64` and `arm64` architectures.
>
> — Microsoft CoPilot

## Testing

1. [Build DesignSafe-CI/DS-User-Guide via Docker.](https://github.com/DesignSafe-CI/DS-User-Guide/blob/dd4a539/README.md#b-via-docker)
2. Verify no errors.

## UI

<details><summary><code>make build</code></summary>

```log
~/Code/DesignSafe-CI/ds-user-guide on  feat/edit-on-github! ⌚ 12:50:32
$ make build
docker compose -f ./docker-compose.yml build
WARN[0000] /Users/wbomar/Code/DesignSafe-CI/ds-user-guide/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Building 25.0s (12/12) FINISHED                                   docker:desktop-linux
 => [docs internal] load build definition from Dockerfile                             0.0s
 => => transferring dockerfile: 702B                                                  0.0s
 => [docs internal] load metadata for docker.io/taccwma/tacc-docs:fix-gh-23-support-  1.6s
 => [docs auth] taccwma/tacc-docs:pull token for registry-1.docker.io                 0.0s
 => [docs internal] load .dockerignore                                                0.0s
 => => transferring context: 2B                                                       0.0s
 => [docs 1/5] FROM docker.io/taccwma/tacc-docs:fix-gh-23-support-macos-docker-user  14.8s
 => => resolve docker.io/taccwma/tacc-docs:fix-gh-23-support-macos-docker-users@sha2  0.0s
 => => sha256:34ff5c0e21abdd1dbd902de4965f4f7de3ee80ed77e834ca06bf 42.49MB / 42.49MB  2.0s
 => => sha256:eec487aa096c6ecf1ad6a4ba5798f7b973d326ab1d693f0c663602 8.05MB / 8.05MB  1.7s
 => => sha256:4ae842846200b88416d3e7d7d31c8274f6ff9c24380ac3c6cd34d00e65 251B / 251B  0.6s
 => => sha256:bc80d134ab9dbaa3982da0033d4d3f4d75ba2c61374e3dbc07c7 24.34MB / 24.34MB  2.9s
 => => sha256:5607e3bb2266df1354616585e5a2203066a29f832e1de3b1072040 6.16MB / 6.16MB  2.4s
 => => sha256:1ae8ab89b79ca6b4fbc5b7006d242a238846ed57f82ebef3fc 189.98MB / 189.98MB  8.5s
 => => sha256:d952be101e4ab063ff4eafa1d2809245e9ac9e713c342da9f201 54.84MB / 54.84MB  3.0s
 => => sha256:a839664fe62f615da74af799f94ccbc890a15d0f78470aac5430 53.76MB / 53.76MB  4.2s
 => => sha256:ca9e545ff305fe56558a94b064a901c16b373a3501daf5519f82 15.54MB / 15.54MB  3.9s
 => => extracting sha256:a839664fe62f615da74af799f94ccbc890a15d0f78470aac54302c2fd54  0.9s
 => => extracting sha256:ca9e545ff305fe56558a94b064a901c16b373a3501daf5519f82ec19db6  0.2s
 => => extracting sha256:d952be101e4ab063ff4eafa1d2809245e9ac9e713c342da9f201d2280d4  1.0s
 => => extracting sha256:1ae8ab89b79ca6b4fbc5b7006d242a238846ed57f82ebef3fc069e6bb0a  3.5s
 => => extracting sha256:5607e3bb2266df1354616585e5a2203066a29f832e1de3b107204086a9d  0.1s
 => => extracting sha256:bc80d134ab9dbaa3982da0033d4d3f4d75ba2c61374e3dbc07c77a74fcd  0.4s
 => => extracting sha256:4ae842846200b88416d3e7d7d31c8274f6ff9c24380ac3c6cd34d00e65a  0.0s
 => => extracting sha256:eec487aa096c6ecf1ad6a4ba5798f7b973d326ab1d693f0c6636023a529  0.2s
 => => extracting sha256:34ff5c0e21abdd1dbd902de4965f4f7de3ee80ed77e834ca06bfaa82afa  0.2s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e  0.0s
 => [docs internal] load build context                                                1.4s
 => => transferring context: 178.50MB                                                 1.4s
 => [docs 2/5] RUN mv /docs /docs-from-tacc                                           0.8s
 => [docs 3/5] COPY ./user-guide/ /docs/                                              0.4s
 => [docs 4/5] RUN cp -r  /docs-from-tacc/mkdocs.base.yml /docs/mkdocs.base.yml &&    0.1s
 => [docs 5/5] RUN mkdir -p /docs/themes/ &&     rm -rf   /docs/themes/tacc-readthed  0.1s
 => [docs] exporting to image                                                         6.9s
 => => exporting layers                                                               5.7s
 => => exporting manifest sha256:96d31949502c030968503b5baa4524ceb22d3a159a835dc1cd3  0.0s
 => => exporting config sha256:f4d7e1b6bb13c8337d7fb62ca034366f8eba82519381b21bec5b7  0.0s
 => => exporting attestation manifest sha256:18ccb7eefac0a65ff568e8a78c5f1e669bbf002  0.0s
 => => exporting manifest list sha256:cb5b39cfacfcdbe11e4dc710db66bba1d520d253daf23e  0.0s
 => => naming to docker.io/library/ds-user-guide-docs:latest                          0.0s
 => => unpacking to docker.io/library/ds-user-guide-docs:latest                       1.1s
 => [docs] resolving provenance for metadata file                                     0.0s
```

</details>


<details><summary><code>make start</code></summary>

```log
docker compose -f docker-compose.yml up
WARN[0000] /Users/wbomar/Code/DesignSafe-CI/ds-user-guide/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 4/4
 ✔ Network ds-user-guide_default         Created                                      0.0s 
 ✔ Volume "ds-user-guide_skip-tacc-js"   Cre...                                       0.0s 
 ✔ Volume "ds-user-guide_skip-tacc-css"  Cr...                                        0.0s 
 ✔ Container ds_docs                     Created                                      0.3s 
Attaching to ds_docs
ds_docs  | WARNING  -  Config value 'site_favicon': Unrecognised configuration name: site_favicon
ds_docs  | WARNING  -  Config value 'dev_addr': The use of the IP address '0.0.0.0' suggests a production environment or the use of a proxy to connect to the MkDocs server. However, the MkDocs' server is intended for local development purposes only. Please use a third party production-ready server instead.
ds_docs  | INFO     -  Building documentation...
ds_docs  | INFO     -  Cleaning site directory
ds_docs  | WARNING  -  Both index.md and README.md found. Skipping README.md from /docs/docs/usecases
ds_docs  | INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
ds_docs  |   - recon.md
ds_docs  |   - redirect.md
ds_docs  |   - analysis/hvsrweb.md
ds_docs  |   - analysis/matlab.md
ds_docs  |   - analysis/overview.md
ds_docs  |   - analysis/swbatch.md
ds_docs  |   - css/README.md
ds_docs  |   - curating/index.md
ds_docs  |   - dictionary/experimental.md
ds_docs  |   - dictionary/field.md
ds_docs  |   - dictionary/hybrid.md
ds_docs  |   - dictionary/other.md
ds_docs  |   - dictionary/simulation.md
ds_docs  |   - js/README.md
ds_docs  |   - managingdata/index.md
ds_docs  |   - tools/simulation.md
ds_docs  |   - tools/hazard/hazardapps.md
ds_docs  |   - tools/hazard/jupyter-dedm.md
ds_docs  |   - tools/hazard/utilities.md
ds_docs  |   - tools/jupyterhub/examplenotebooks.md
ds_docs  |   - tools/jupyterhub/jupyterhub.md
ds_docs  |   - tools/jupyterhub/jupyterlabhpc.md
ds_docs  |   - tools/jupyterhub/jupytersomething.md
ds_docs  |   - tools/jupyterhub/publishingnotebooks.md
ds_docs  |   - tools/simulation/opensees.md
ds_docs  |   - tools/simulation/adcirc/adcirc_cli.md
ds_docs  |   - tools/simulation/adcirc/installation.md
ds_docs  |   - tools/simulation/adcirc/examples/examples.md
ds_docs  |   - tools/simulation/adcirc/examples/quarter_annular_harbor.md
ds_docs  |   - tools/simulation/adcirc/examples/shinnecock.md
ds_docs  |   - tools/simulation/adcirc/inputs/fort_14.md
ds_docs  |   - tools/simulation/adcirc/inputs/fort_15.md
ds_docs  |   - tools/simulation/adcirc/inputs/inputs.md
ds_docs  |   - tools/simulation/adcirc/outputs/outputs.md
ds_docs  |   - tools/simulation/opensees/OSApplications.md
ds_docs  |   - tools/simulation/opensees/OSDesignSafe.md
ds_docs  |   - tools/simulation/opensees/OSPlatforms.md
ds_docs  |   - tools/simulation/opensees/openseesApplications.md
ds_docs  |   - tools/simulation/opensees/openseesApplicationsNotes.md
ds_docs  |   - tools/simulation/opensees/openseesDecisionMatrixApplication.md
ds_docs  |   - tools/simulation/opensees/openseesDecisionMatrixPlatform.md
ds_docs  |   - tools/simulation/opensees/openseesDesignSafeQuickStart.md
ds_docs  |   - tools/simulation/opensees/openseesExpress.md
ds_docs  |   - tools/simulation/opensees/openseesHardware.md
ds_docs  |   - tools/simulation/opensees/openseesMP.md
ds_docs  |   - tools/simulation/opensees/openseesOverview.md
ds_docs  |   - tools/simulation/opensees/openseesProjectSize.md
ds_docs  |   - tools/simulation/opensees/openseesPy.md
ds_docs  |   - tools/simulation/opensees/openseesResources.md
ds_docs  |   - tools/simulation/opensees/openseesRunJupyterHPC.md
ds_docs  |   - tools/simulation/opensees/openseesRunJupyterPy.md
ds_docs  |   - tools/simulation/opensees/openseesRunLinux.md
ds_docs  |   - tools/simulation/opensees/openseesRunTACC.md
ds_docs  |   - tools/simulation/opensees/openseesRunVM.md
ds_docs  |   - tools/simulation/opensees/openseesRunVM_Specs.md
ds_docs  |   - tools/simulation/opensees/openseesRunWebPortal.md
ds_docs  |   - tools/simulation/opensees/openseesRunWebPortal_Form.md
ds_docs  |   - tools/simulation/opensees/openseesRunWebPortal_Specs.md
ds_docs  |   - tools/simulation/opensees/openseesRunning.md
ds_docs  |   - tools/simulation/opensees/openseesSP.md
ds_docs  |   - tools/simulation/openseesOld/openseesOverview.md
ds_docs  |   - tools/simulation/openseesOld/openseesResources.md
ds_docs  |   - tools/simulation/openseesOld/openseesSubmitJob.md
ds_docs  |   - tools/simulation/openseesOld/openseesTutorial.md
ds_docs  |   - tools/visualization/figuregen.md
ds_docs  |   - tools/visualization/hazmapper.md
ds_docs  |   - tools/visualization/kalpana.md
ds_docs  |   - tools/visualization/overview.md
ds_docs  |   - tools/visualization/paraview.md
ds_docs  |   - tools/visualization/potree-converter.md
ds_docs  |   - tools/visualization/potree-viewer.md
ds_docs  |   - tools/visualization/qgis.md
ds_docs  |   - tools/visualization/stko.md
ds_docs  |   - tools/visualization/visit.md
ds_docs  |   - usecases/index.md
ds_docs  |   - usecases/apiusecases.md
ds_docs  |   - usecases/dataanalyticsusecases.md
ds_docs  |   - usecases/geohazardusecases.md
ds_docs  |   - usecases/seismicusecases.md
ds_docs  |   - usecases/windstormsurgeusecases.md
ds_docs  |   - usecases/arduino/usecase_matlab.md
ds_docs  |   - usecases/arduino/usecase_quoFEM.md
ds_docs  |   - usecases/arduino/usecase_siteResponse.md
ds_docs  |   - usecases/brandenberg-api/license.md
ds_docs  |   - usecases/usgs_api/usecase.md
ds_docs  | WARNING  -  Documentation file 'usecases/overview.md' contains a link to 'usecases/img/data.png' which is not found in the documentation files.
ds_docs  | WARNING  -  Documentation file 'usecases/overview.md' contains a link to 'usecases/img/geo.png' which is not found in the documentation files.
ds_docs  | WARNING  -  Documentation file 'usecases/overview.md' contains a link to 'usecases/img/seismic.jpg' which is not found in the documentation files.
ds_docs  | WARNING  -  Documentation file 'usecases/overview.md' contains a link to 'usecases/img/wind.png' which is not found in the documentation files.
ds_docs  | INFO     -  Documentation built in 14.24 seconds
ds_docs  | INFO     -  [18:51:24] Watching paths for changes: 'docs', 'mkdocs.yml', 'themes/tacc-readthedocs', '/opt/pysetup/.venv/lib/python3.11/site-packages/mkdocs/themes/readthedocs', '/opt/pysetup/.venv/lib/python3.11/site-packages/mkdocs/templates', '/opt/pysetup/.venv/lib/python3.11/site-packages/mkdocs/contrib/search/templates', 'docs/analysis/hvsrweb.md', 'docs/analysis/matlab.md', 'docs/analysis/swbatch.md', 'docs/dictionary/experimental.md', 'docs/dictionary/simulation.md', 'docs/dictionary/hybrid.md', 'docs/dictionary/field.md', 'docs/dictionary/other.md', 'docs/redirect.md', 'docs/tools/hazard/hazardapps.md', 'docs/tools/hazard/jupyter-dedm.md', 'docs/tools/hazard/utilities.md', 'docs/tools/jupyterhub/jupyterhub.md', 'docs/tools/jupyterhub/jupyterlabhpc.md', 'docs/tools/jupyterhub/examplenotebooks.md', 'docs/tools/jupyterhub/publishingnotebooks.md', 'docs/tools/simulation/overview.md', 'docs/tools/simulation/adcirc/adcirc.md', 'docs/tools/simulation/adcirc/adcirc_cli.md', 'docs/tools/simulation/adcirc/inputs/inputs.md', 'docs/tools/simulation/adcirc/outputs/outputs.md', 'docs/tools/simulation/adcirc/examples/examples.md', 'docs/tools/simulation/adcirc/examples/quarter_annular_harbor.md', 'docs/tools/simulation/adcirc/examples/shinnecock.md', 'docs/tools/simulation/adcirc/installation.md', 'docs/tools/simulation/clawpack.md', 'docs/tools/simulation/dakota.md', 'docs/tools/simulation/in-core.md', 'docs/tools/simulation/lsdyna.md', 'docs/tools/simulation/openfoam.md', 'docs/tools/simulation/opensees.md', 'docs/tools/visualization/figuregen.md', 'docs/tools/visualization/hazmapper.md', 'docs/tools/visualization/kalpana.md', 'docs/tools/visualization/paraview.md', 'docs/tools/visualization/potree-converter.md', 'docs/tools/visualization/potree-viewer.md', 'docs/tools/visualization/qgis.md', 'docs/tools/visualization/stko.md', 'docs/usecases/haan/usecase.md', 'docs/usecases/haan/usecase-2.md', 'docs/tools/visualization/visit.md', 'docs/tools/simulation/opensees/openseesDesignSafeQuickStart.md', 'docs/usecases/vantassel_and_zhang/usecase.md', 'docs/usecases/padgett/usecase_JN_viz.md', 'docs/usecases/brandenberg-ngl/usecase.md', 'docs/usecases/kumar/usecase.md', 'docs/usecases/dawson/usecase.md', 'docs/usecases/dawson/usecase2.md', 'docs/usecases/padgett/usecase.md', 'docs/usecases/kareem/usecase.md', 'docs/usecases/pinelli/usecase.md', 'docs/usecases/arduino/usecase.md', 'docs/usecases/lowes/usecase.md', 'docs/usecases/rathje/usecase.md', 'docs/usecases/mosqueda/usecase.md', 'docs/usecases/brandenberg-api/usecase.md', 'docs/usecases/haan/usecase-3.md', 'docs/usecases/mosqueda/erler-mosqueda.md', 'docs/usecases/pinelli/2usecase.md', 'docs/usecases/kareem/usecase2.md', 'docs/usecases/kareem/usecase3.md'
ds_docs  | INFO     -  [18:51:24] Serving on http://0.0.0.0:8000/user-guide/
ds_docs  | INFO     -  [18:51:36] Browser connected: http://0.0.0.0:8000/user-guide/
```

</details>

<img width="845" alt="tacc-docs-pr-58" src="https://github.com/user-attachments/assets/553946a4-e482-4f58-b327-73c467c6dba3">

## Notes

TACC-Docs needs this, but others projects do not, because other projects **either** work on macOS arm64 because they are built via Jenkins e.g. Core-CMS **or** are never used on macOS e.g. Core-CMS-Custom.