### PR TITLE
chore: remove unnecessary runs_on build param

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,23 +2,13 @@ name: TACC Docs Build
 
 on:
   workflow_dispatch:
-    inputs:
-      runs_on:
-        description: 'On which operating system to run the build'
-        required: false
-        default: 'ubuntu-latest' # default for manual run
-        type: choice
-        options:
-        - ubuntu-latest
-        - macos-latest
   push:
     branches:
       - main
 
 jobs:
   docker:
-    # default for automatic run on 'push'
-    runs-on: ${{ github.event_name == 'push' && 'ubuntu-latest' || inputs.runs_on }}
+    runs-on: ubuntu-latest
     steps:
       -
         name: Set up Docker Buildx


### PR DESCRIPTION
## Overview

Remove unnecessary code that was trying to fix #23.

## Related

- allowed since #58

## Changes

- **reverted** build config

## Testing

1. Run a build on this branch.
2. Verify success.

## UI

https://github.com/TACC/TACC-Docs/actions/runs/11920874490