### PR TITLE
fix: exclude redundant search results

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,10 +80,9 @@ plugins:
       exclude:
         - aliases.md
         - include/*
-        - index-sample/*
         - code-examples/*
         - testingextensions.md
-        - archives/*
+      exclude_unreferenced: true
   - macros # allows {% include ... %} (and macros)
 # TODO: Restore this
 #  - with-pdf:


### PR DESCRIPTION
## Overview

Exclude redundant items from search.

<details><summary>Problem This Change Solves</summary>

Search normally shows results for content from all pages. But this repo includes pages (via [macros `include`](https://mkdocs-macros-plugin.readthedocs.io/en/stable/advanced/#including-external-files-in-pages) and [`makefile`s](https://github.com/search?q=repo%3ATACC%2FTACC-Docs+language%3AMakefile&type=code)) into other pages. So when user searches "A", which is on page "X", which is included on page "Y"; then search results show page "X" and page "Y". In this repository, page "X" is usually not in the navigation, while page "Y" is. So, visiting page "X" from search results shows a page with no relevant navigation revealed.

</details>
<details><summary>How This Change Solves It</summary>

This change excludes all content from search that are on pages that are not directly included by navigation i.e. it excludes and pages included via [macros `include`](https://mkdocs-macros-plugin.readthedocs.io/en/stable/advanced/#including-external-files-in-pages) and [`makefile`s](https://github.com/search?q=repo%3ATACC%2FTACC-Docs+language%3AMakefile&type=code) e.g. page "X" (an example described in "Problem This Change Solves").

</details>

## Related

- mimics https://github.com/DesignSafe-CI/DS-User-Guide/pull/107

## Changed

- **added** a setting
- **remvoed** unnecessary direct search exclusions

## Testing

1. Search for a phrase that is in the docs on a page that is included in another page.
2. See zero duplicate results.

## UI

https://github.com/user-attachments/assets/65eb2199-2187-4773-be09-0ac9c62bb6e1

https://github.com/user-attachments/assets/5d17c4bb-6445-41f7-a63d-95e05f14c18a

_The first result "Frontera User Guide Last update: October 30, 2024 Important : (10-15-2024) Please note TACC's new SU charge policy ." is missing because it is on a [`notices.md`](https://github.com/TACC/TACC-Docs/blob/be65992/docs/hpc/frontera/notices.md) page that is not included by navigation. (It is included via internal `makefile`s.)_