### PR TITLE
feat: core-styles update / from purple to blue

### DIFF
--- a/docs/css/core/core-styles.css
+++ b/docs/css/core/core-styles.css
@@ -2,8 +2,8 @@
 /* https://github.com/TACC/Core-Styles */
 /* https://tacc-main.atlassian.net/wiki/x/qA9v */
 
-@import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2.29.0/dist/core-styles.base.css') layer(base);
-@import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2.29.0/dist/core-styles.docs.css') layer(project);
+@import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2.37.3/dist/core-styles.base.css') layer(base);
+@import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2.37.3/dist/core-styles.docs.css') layer(project);
 
 /* CORE STYLES: Base */
 @layer base {


### PR DESCRIPTION
## Overview / Changes

- Update Core-Styles from 2.29 to 2.37.
- Changes accent color from purple to blue (like Portal & CMS).

## Related

as done in:
- https://github.com/TACC/tup-ui/pull/476
- https://github.com/TACC/Core-Styles/releases/tag/v2.32.0
- https://github.com/TACC/Core-CMS/releases/tag/v4.15.0

## Testing

1. Open any page(s).
2. Verify accent color is blue, not purple.

## UI

| before | after |
| - | - |
| <img width="960" alt="before" src="https://github.com/user-attachments/assets/d170275c-03fc-47ef-bfc1-136e5aeb97c1" /> | <img width="960" alt="after" src="https://github.com/user-attachments/assets/945e9ffc-7ba1-4595-b861-8925a120c033" /> |
