### PR TITLE
deps: core-styles v2.37.4

### DIFF
--- a/docs/css/core/core-styles.css
+++ b/docs/css/core/core-styles.css
@@ -2,8 +2,8 @@
 /* https://github.com/TACC/Core-Styles */
 /* https://tacc-main.atlassian.net/wiki/x/qA9v */
 
-@import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2.37.3/dist/core-styles.base.css') layer(base);
-@import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2.37.3/dist/core-styles.docs.css') layer(project);
+@import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2.37.4/dist/core-styles.base.css') layer(base);
+@import url('https://cdn.jsdelivr.net/npm/@tacc/core-styles@2.37.4/dist/core-styles.docs.css') layer(project);
 
 /* CORE STYLES: Base */
 @layer base {


### PR DESCRIPTION
## Overview

Update Core-Styles.

## Notes

Adds a fix from Core-Styles that is not used except in https://github.com/TACC/TACC-Docs/pull/68.
