### PR TITLE
fix: edit link text incorrect (on deploy at least)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_name: TACC HPC Documentation
 site_description: TACC Technical Documentation
 site_author: Susan Lindsey
 site_url: https://docs.tacc.utexas.edu
-# repo_url: https://github.com/TACC/TACC-Docs
+repo_url: https://github.com/TACC/TACC-Docs
 # edit_uri: edit/main/docs/
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_name: TACC HPC Documentation
 site_description: TACC Technical Documentation
 site_author: Susan Lindsey
 site_url: https://docs.tacc.utexas.edu
-repo_url: https://github.com/TACC/TACC-Docs
+# repo_url: https://github.com/TACC/TACC-Docs
 # edit_uri: edit/main/docs/
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ site_name: TACC HPC Documentation
 site_description: TACC Technical Documentation
 site_author: Susan Lindsey
 site_url: https://docs.tacc.utexas.edu
-repo_url: https://github.com/TACC/TACC-Docs
-edit_uri: edit/main/docs/
+# repo_url: https://github.com/TACC/TACC-Docs
+# edit_uri: edit/main/docs/
 
 theme:
     analytics:


### PR DESCRIPTION
## Overview

The edit link should say "Suggest an edit via GitHub", but says "Edit on GitHub".

## Related

- reverts #57

## Changes

- unset edit link

## Testing

1. `make build`
2. `make start`
3. open site
4. verify no edit link

## UI

| before | after |
| - | - |
| <img width="958" alt="before" src="https://github.com/user-attachments/assets/65c99c30-d0f2-42df-b33a-5bdc89a21ecb" /> | <img width="958" alt="after" src="https://github.com/user-attachments/assets/a4033295-2697-4823-9fcb-4400ce3db879" /> |