### PR TITLE
docs: move advanced stuff out of readme

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,6 @@
 # How to Develop
 
-We use [Poetry](https://python-poetry.org/) to manage dependencies. We deploy via [Docker](https://www.docker.com/) and strongly suggest development via Docker.
+Manage dependencies via [Poetry](https://python-poetry.org/). Serve docs via [MkDocs](https://www.mkdocs.org/). Test via [Docker](https://www.docker.com/). Deploys are [automated](https://github.com/TACC/TACC-Docs/blob/main/PUBLISHING.md).
 
 ## Testing
 
@@ -8,9 +8,9 @@ Testing is manual and requires using a command prompt. You can test [via Python]
 
 ## Theming
 
-We use custom files ([CSS, JS, ES, plugins, extensions](https://github.com/TACC/TACC-Docs/blob/v0.15.0/mkdocs.base.yml), and [overrides](https://github.com/TACC/TACC-Docs/tree/v0.15.0/themes/tacc-readthedocs)) to customize MkDocs.
+Customize MkDocs with [CSS, JS, ES, plugins, extensions](https://github.com/TACC/TACC-Docs/blob/v0.15.0/mkdocs.base.yml) and [theme overrides](https://github.com/TACC/TACC-Docs/tree/v0.15.0/themes/tacc-readthedocs)).
 
 To theme another MkDocs project to look [like this](https://docs.tacc.utexas.edu/), please contact [@wesleyboar](https://www.github.com/wesleyboar).
 
 > [!NOTE]
-> We will eventually [update our theme to MkDocs Material](https://github.com/TACC/TACC-Docs/issues/53) and [offer our theme properly](https://github.com/TACC/TACC-Docs/issues/76).
+> We will eventually [use MkDocs Material](https://github.com/TACC/TACC-Docs/issues/53) and [offer our customization properly](https://github.com/TACC/TACC-Docs/issues/76).

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,16 @@
+# How to Develop
+
+We use [Poetry](https://python-poetry.org/) to manage dependencies. We deploy via [Docker](https://www.docker.com/) and strongly suggest development via Docker.
+
+## Testing
+
+Testing is manual and requires using a command prompt. You can test [via Python](./TESTING.md#a-via-python) or [via Docker](./TESTING.md#b-via-docker).
+
+## Theming
+
+We use custom files ([CSS, JS, ES, plugins, extensions](https://github.com/TACC/TACC-Docs/blob/v0.15.0/mkdocs.base.yml), and [overrides](https://github.com/TACC/TACC-Docs/tree/v0.15.0/themes/tacc-readthedocs)) to customize MkDocs.
+
+To theme another MkDocs project to look [like this](https://docs.tacc.utexas.edu/), please contact [@wesleyboar](https://www.github.com/wesleyboar).
+
+> [!NOTE]
+> We will eventually [update our theme to MkDocs Material](https://github.com/TACC/TACC-Docs/issues/53) and [offer our theme properly](https://github.com/TACC/TACC-Docs/issues/76).

--- a/README.md
+++ b/README.md
@@ -6,14 +6,10 @@ Built with [MkDocs](https://mkdocs.readthedocs.io/) and a **customized** [ReadTh
 
 We welcome contributions, offer a guide for those new to GitHub, and a style guide to simplify reviews. [Read more](./CONTRIBUTING.md).
 
-## Testing
-
-Testing is manual and requires using a command prompt. You can test [via Python](./TESTING.md#a-via-python) or [via Docker](./TESTING.md#b-via-docker).
-
 ## Publishing
 
 We automatically publish `main` branch commits. We manually release versions of TACC-Docs. [Read more](./PUBLISHING.md).
 
-## Theming
+## Developing
 
-To theme your documentation like TACC, please contact [@wesleyboar](https://www.github.com/wesleyboar) or mimic [DS-User-Guide](https://github.com/DesignSafe-CI/DS-User-Guide/).
+We use [Poetry](https://python-poetry.org/) and [Docker](https://www.docker.com/). [Read more](./DEVELOPING.md).

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ We automatically publish `main` branch commits. We manually release versions of 
 
 ## Developing
 
-We use [Poetry](https://python-poetry.org/), [Docker](https://www.docker.com/), [MkDocs](https://mkdocs.readthedocs.io/) and [MkDocs' "ReadTheDocs" theme](https://www.mkdocs.org/user-guide/choosing-your-theme/#readthedocs) (customized). [Read more](./DEVELOPING.md).
+We use [Poetry](https://python-poetry.org/), [Docker](https://www.docker.com/), [MkDocs](https://mkdocs.readthedocs.io/) and a customized theme. [Read more](./DEVELOPING.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TACC Docs
 
-Built with [MkDocs](https://mkdocs.readthedocs.io/) and a **customized** [ReadTheDocs](https://www.mkdocs.org/user-guide/choosing-your-theme/#readthedocs) theme.
+TACC's system documentation at [docs.tacc.utexas.edu](https://docs.tacc.utexas.edu).
 
 ## Contributing
 
@@ -12,4 +12,4 @@ We automatically publish `main` branch commits. We manually release versions of 
 
 ## Developing
 
-We use [Poetry](https://python-poetry.org/) and [Docker](https://www.docker.com/). [Read more](./DEVELOPING.md).
+We use [Poetry](https://python-poetry.org/), [Docker](https://www.docker.com/), [MkDocs](https://mkdocs.readthedocs.io/) and [MkDocs' "ReadTheDocs" theme](https://www.mkdocs.org/user-guide/choosing-your-theme/#readthedocs) (customized). [Read more](./DEVELOPING.md).

--- a/TESTING.md
+++ b/TESTING.md
@@ -26,7 +26,7 @@
 
 ### B. Via Docker
 
-0. Have Docker installed.\
+0. Have [Docker](https://www.docker.com/) installed.\
     <sup>We recommend doing so via [Docker-Desktop](https://www.docker.com/products/docker-desktop).</sup>
 1. Navigate into your clone of this repository.
 2. Start the Docker container to serve the docs.


### PR DESCRIPTION
## Overview

To welcome new contributors, not confuse nor worry them, move the advanced stuff out of the README.

## Related

- improves #70

## Changes

- added `DEVELOPING.md`
- moved "Testing" overview to `DEVELOPING.md` 
- moved "Theming" overview to `DEVELOPING.md`
- added "Developing" overview to `README.md`
- changed `TESTING.md` to link to Docker

## Testing

1. Evaluate [`README.md`](https://github.com/TACC/TACC-Docs/blob/docs/move-adv-stuff-out-of-readme/README.md).
    - Is it simpler?
    - Is advanced stuff out of the way.
 2. Evaluate [`DEVELOPING.md`](https://github.com/TACC/TACC-Docs/blob/docs/move-adv-stuff-out-of-readme/DEVELOPING.md).
     - Is it simple?
     - Does dev know where to learn more?
