### PR TITLE
docs: pr template - add simple one, hide dev one

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/developer.md
+++ b/.github/PULL_REQUEST_TEMPLATE/developer.md
@@ -1,0 +1,29 @@
+## Overview
+
+…
+
+## Related
+
+<!--
+- [TUP-XYZ](https://tacc-main.atlassian.net/browse/TUP-123)
+- requires _some_other_pr_
+- required by _some_other_pr_
+-->…
+
+## Changes
+
+…
+
+## Testing
+
+1.
+
+## UI
+
+…
+
+<!--
+## Notes
+
+…
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,5 @@
-## Overview
+<!-- What did you change? -->
 
-…
+<!-- Do you want support (syntax, design, etc)? -->
 
-## Related
-
-<!--
-- [FP-123](https://tacc-main.atlassian.net/browse/FP-123)
-- requires https://github.com/TACC/Core-CMS/pull/117
--->…
-
-## Changes
-
-…
-
-## Testing
-
-1.
-
-## UI
-
-…
-
-<!--
-## Notes
-
-…
--->
+<!-- Any reference material worth sharing? -->


### PR DESCRIPTION
## Overview & Changes

- Add user PR template.
- Hide dev PR template.

## Testing & UI

Skipped. No content to show. It's comments.

## Notes

I'd love to support both, but GitHub does not give an option to users. GitHub purports to support a choice via URL, but I never see it work.