### PR TITLE
docs(CONTRIBUTING): link to demo of enabled extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ All contributions should be made via a GitHub pull request.  The pull requests w
 
 * Use [Markdown](https://www.markdownguide.org/) for your source text.
 * Use `cwd`-relative paths to images e.g. instead of `/hpc/imgs/myimage.png`, use `../imgs/myimage.png` so that images load on the website **and** in GitHub preview.
-* Some [Python-Markdown extensions](https://python-markdown.github.io/extensions/) and [PyMdown exensions](https://facelessuser.github.io/pymdown-extensions/#extensions) are enabled.  See enabled extensions at [`mkdocs.base.yml`](https://github.com/TACC/TACC-Docs/blob/main/mkdocs.base.yml) under `markdown_extensions:`.
+* We offer features, a.k.a extensions, to help authors present content more effectively. Review [demos of enabled extensions](https://tacc.github.io/mkdocs-tacc/extensions/#demos).
 
 ### Writing Commit Messages
 


### PR DESCRIPTION
Changed bullet **from** links to technical docs for extensions **to** links to demo of features for authors to effectively communicate.