### PR TITLE
fix: alphafold3, move image out of table

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -12,3 +12,10 @@ footer {
 [class*="card--"] i.fa {
     margin-block: -1rem 1rem;
 }
+
+/* to limit width of aligned images */
+/* https://github.com/TACC/Core-Styles/blob/v2.43.2/src/lib/_imports/components/align.css#L33 */
+.align-right,
+.align-left {
+  max-width: 25vw;
+}

--- a/docs/software/alphafold3.md
+++ b/docs/software/alphafold3.md
@@ -1,7 +1,5 @@
 # AlphaFold3 at TACC
 *Last update: April 8, 2025*
-# AlphaFold3 at TACC
-*Last update: April 8, 2025*
 
 ![AlphaFold logo](../imgs/alphafold3-logo.png){ .align-right }
 

--- a/docs/software/alphafold3.md
+++ b/docs/software/alphafold3.md
@@ -1,10 +1,9 @@
 # AlphaFold3 at TACC
 *Last update: April 8, 2025*
+# AlphaFold3 at TACC
+*Last update: April 8, 2025*
 
-<figure class="align-right">
-    <img src="../imgs/alphafold3-logo.png" alt="AlphaFold logo">
-    <figcaption>AlphaFold logo</figcaption>
-</figure>
+![AlphaFold logo](../imgs/alphafold3-logo.png){ .align-right }
 
 AlphaFold3 is Google Deepmind's latest deep learning model for predicting the structure and interactions of biological macromolecules, including proteins, nucleic acids, small molecules, ions, and post-translational modifications. AlphaFold3 significantly expands the capabilities of AlphaFold2, offering highly accurate complex structure predictions beyond protein folding alone. In November 2024, the developers made the [source code available on Github](https://github.com/deepmind/alphafold) and published a [Nature paper](https://www.nature.com/articles/s41586-024-07487-w) ([supplementary information](https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-024-07487-w/MediaObjects/41586_2024_7487_MOESM1_ESM.pdf)) describing the method. In addition to the software, AlphaFold3 depends on ~253 GB of databases and model parameters. Researchers interested in making protein structure predictions with AlphaFold3 are encouraged to follow the guide below, and use the databases that have been prepared.
 

--- a/docs/software/alphafold3.md
+++ b/docs/software/alphafold3.md
@@ -1,10 +1,12 @@
 # AlphaFold3 at TACC
 *Last update: April 8, 2025*
 
+<figure class="align-right">
+    <img src="../imgs/alphafold3-logo.png" alt="AlphaFold logo">
+    <figcaption>AlphaFold logo</figcaption>
+</figure>
 
-<table cellpadding="5" cellspacing="5"><tr>
-<td> <img alt="AlphaFold logo" src="../imgs/alphafold3-logo.png"></td><td>
-AlphaFold3 is Google Deepmind's latest deep learning model for predicting the structure and interactions of biological macromolecules, including proteins, nucleic acids, small molecules, ions, and post-translational modifications. AlphaFold3 significantly expands the capabilities of AlphaFold2, offering highly accurate complex structure predictions beyond protein folding alone. In November 2024, the developers made the <a href="https://github.com/deepmind/alphafold">source code available on Github</a> and published a <a href="https://www.nature.com/articles/s41586-024-07487-w">Nature paper</a> (<a href="https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-024-07487-w/MediaObjects/41586_2024_7487_MOESM1_ESM.pdf">supplementary information</a>) describing the method. In addition to the software, AlphaFold3 depends on ~253 GB of databases and model parameters. Researchers interested in making protein structure predictions with AlphaFold3 are encouraged to follow the guide below, and use the databases that have been prepared.</td></tr></table>
+AlphaFold3 is Google Deepmind's latest deep learning model for predicting the structure and interactions of biological macromolecules, including proteins, nucleic acids, small molecules, ions, and post-translational modifications. AlphaFold3 significantly expands the capabilities of AlphaFold2, offering highly accurate complex structure predictions beyond protein folding alone. In November 2024, the developers made the [source code available on Github](https://github.com/deepmind/alphafold) and published a [Nature paper](https://www.nature.com/articles/s41586-024-07487-w) ([supplementary information](https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-024-07487-w/MediaObjects/41586_2024_7487_MOESM1_ESM.pdf)) describing the method. In addition to the software, AlphaFold3 depends on ~253 GB of databases and model parameters. Researchers interested in making protein structure predictions with AlphaFold3 are encouraged to follow the guide below, and use the databases that have been prepared.
 
 ## Installations at TACC { #installations } 
 


### PR DESCRIPTION
Moved image out of table, because neither the image nor content was tabular data.

I added extra css to extend existing `align-right` class, as suggested by Core-Styles.[^1]

| narrow screen | wide screen |
| - | - |
| <img width="517" alt="narrow screen" src="https://github.com/user-attachments/assets/e281fedb-c0fc-44c5-bbcd-63f75d4b27fd" /> | <img width="960" alt="wide screen" src="https://github.com/user-attachments/assets/00059436-f623-45e3-b3fa-bd9b597cb78f" /> | 

[^1]: I would consider moving this CSS to https://github.com/TACC/mkdocs-tacc if another of [its clients](https://github.com/TACC/mkdocs-tacc/tree/main?tab=readme-ov-file#known-clients) adds decorative inline imagery.

Included in #115.