### PR TITLE
fix: deprecated html & lost styles

### DIFF
--- a/docs/software/alphafold.md
+++ b/docs/software/alphafold.md
@@ -2,7 +2,7 @@
 *Last update: February 26, 2025*
 
 <!-- ![AlphaFold logo](../imgs/alphafold-logo.png){ .align-right } -->
-<img src="../imgs/alphafold-logo.png" width="250" alt="AlphaFold logo" align="right">
+<img src="../imgs/alphafold-logo.png" width="250" alt="AlphaFold logo" class="align-right">
 
 AlphaFold2 is a protein structure prediction tool developed by DeepMind (Google). AlphaFold2 uses a novel machine learning approach to predict 3D protein structures from primary sequences alone. In July 2021, the developers made the [source code available on Github](https://github.com/deepmind/alphafold) and published a [Nature paper](https://www.nature.com/articles/s41586-021-03819-2) ([supplementary information](https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-021-03819-2/MediaObjects/41586_2021_3819_MOESM1_ESM.pdf)) describing the method. In addition to the software, AlphaFold2 depends on ~2.9 TB of databases and model parameters. Researchers interested in making protein structure predictions with AlphaFold2 are encouraged to follow the guide below, and use the databases and model parameters that have been prepared.
 

--- a/docs/software/alphafold3.md
+++ b/docs/software/alphafold3.md
@@ -2,7 +2,7 @@
 *Last update: May 5, 2025*
 
 <!-- ![AlphaFold logo](../imgs/alphafold3-logo.png){ .align-right } -->
-<img src="../imgs/alphafold3-logo.png" width="250" alt="AlphaFold3 logo" align="right">
+<img src="../imgs/alphafold3-logo.png" width="250" alt="AlphaFold3 logo" class="align-right">
 
 AlphaFold3 is Google Deepmind's latest deep learning model for predicting the structure and interactions of biological macromolecules, including proteins, nucleic acids, small molecules, ions, and post-translational modifications. AlphaFold3 significantly expands the capabilities of AlphaFold2, offering highly accurate complex structure predictions beyond protein folding alone. In November 2024, the developers made the [source code available on Github](https://github.com/deepmind/alphafold) and published a [Nature paper](https://www.nature.com/articles/s41586-024-07487-w) ([supplementary information](https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-024-07487-w/MediaObjects/41586_2024_7487_MOESM1_ESM.pdf)) describing the method. In addition to the software, AlphaFold3 depends on ~253 GB of databases and model parameters. Researchers interested in making protein structure predictions with AlphaFold3 are encouraged to follow the guide below, and use the databases that have been prepared.
 

--- a/docs/software/ansys.md
+++ b/docs/software/ansys.md
@@ -2,7 +2,7 @@
 *Last update: June 12, 2024*
 
 <!-- ![ANSYS logo](../imgs/ansys-logo.png){ .align-right width="200px" } -->
-<img src="../imgs/ansys-logo.png" width="250" alt="ANSYS logo" align="right">
+<img src="../imgs/ansys-logo.png" width="250" alt="ANSYS logo" class="align-right">
 
 ANSYS offers a comprehensive software suite that spans the entire range of physics, providing access to virtually any field of engineering simulation that a design process requires. ANSYS software is used to simulate computer models of structures, electronics, or machine components for analyzing strength, toughness, elasticity, temperature distribution, electromagnetism, fluid flow, and other attributes.
 

--- a/docs/software/gaussian.md
+++ b/docs/software/gaussian.md
@@ -2,7 +2,7 @@
 *Last update: April 22, 2024* 
 
 <!-- ![Gaussian logo](../imgs/gaussian-logo.png){ .align-left } -->
-<img src="../imgs/gaussian-logo.png" width="300" alt="Gaussian logo" align="right">
+<img src="../imgs/gaussian-logo.png" width="300" alt="Gaussian logo" class="align-right">
 
 Gaussian is a quantum mechanics package for calculating molecular properties from first principles. From the Gaussian website:
 

--- a/docs/software/gromacs.md
+++ b/docs/software/gromacs.md
@@ -2,7 +2,7 @@
 *Last update: April 28, 2025*
 
 <!-- ![GROMACS logo](../imgs/gromacs-logo.png){ .align-right width="200px" } -->
-<img src="../imgs/gromacs-logo.png" width="300" alt="GROMACS logo" align="right">
+<img src="../imgs/gromacs-logo.png" width="300" alt="GROMACS logo" class="align-right">
 
 GROMACS is a free, open-source, molecular dynamics package. GROMACS can simulate the Newtonian equations of motion for systems with hundreds to millions of particles. GROMACS is primarily designed for biochemical molecules like proteins, lipids and nucleic acids that have a lot of complicated bonded interactions, but since GROMACS is extremely fast at calculating the nonbonded interactions (that usually dominate simulations), many groups are also using it for research on non-biological systems, e.g., polymers.
 

--- a/docs/software/lammps.md
+++ b/docs/software/lammps.md
@@ -2,7 +2,7 @@
 *Last update: March 11, 2024*
 
 <!-- ![LAMMPS logo](../imgs/lammps-logo.png){ .align-right } -->
-<img src="../imgs/lammps-logo.png" width="300" alt="LAMMPS logo" align="right">
+<img src="../imgs/lammps-logo.png" width="300" alt="LAMMPS logo" class="align-right">
 
 LAMMPS is a classical molecular dynamics code developed at Sandia National Laboratories and is available under the GPL license. LAMMPS (<b>L</b>arge-scale <b>A</b>tomic/<b>M</b>olecular <b>M</b>assively <b>P</b>arallel <b>S</b>imulator) makes use of spatial-decomposition techniques to partition the simulation domain.  LAMMPS runs in serial or in parallel using MPI. The code is capable of modeling systems with millions or even billions of particles on a large High Performance Computing machine. A variety of force fields and boundary conditions are provided in LAMMPS which can be used to model atomic, polymeric, biological, metallic, granular, and coarse-grained systems.
 

--- a/docs/software/matlab.md
+++ b/docs/software/matlab.md
@@ -2,7 +2,7 @@
 *Last update: January 16, 2024* 
 
 <!-- ![MATLAB logo](../imgs/matlab-logo.png){ .align-left width="75px" } -->
-<img src="../imgs/matalb-logo.png" width="300" alt="MATLAB logo" align="right">
+<img src="../imgs/matalb-logo.png" width="300" alt="MATLAB logo" class="align-right">
 
 [Mathwork's](https://www.mathworks.com/) MATLAB is installed and supported at TACC and is available on the following TACC resources: [Frontera][TACCFRONTERAUG], [Stampede3][TACCSTAMPEDE3UG] and [Lonestar6][TACCLONESTAR6UG].  
 

--- a/docs/software/namd.md
+++ b/docs/software/namd.md
@@ -2,7 +2,7 @@
 *Last update: April 28, 2025*
 
 <!-- ![NAMD logo](../imgs/namd-logo.png){ .align-right } -->
-<img src="../imgs/namd-logo.png" width="300" alt="NAMD logo" align="right">
+<img src="../imgs/namd-logo.png" width="300" alt="NAMD logo" class="align-right">
 
 [NAMD](http://www.ks.uiuc.edu/Research/namd/), **Na**noscale **M**olecular **D**ynamics program, is a parallel molecular dynamics code designed for high-performance simulation of large biomolecular systems. Based on Charm++ parallel objects, NAMD scales to hundreds of cores for typical simulations and beyond 500,000 cores for the largest simulations. NAMD uses the popular molecular graphics program VMD for simulation setup and trajectory analysis, but is also file-compatible with AMBER, CHARMM, and X-PLOR. NAMD can perform geometry optimization, molecular dynamics simulations, chemical and conformational free energy calculations, enhanced sampling via replica exchange. It also supports Tcl based scripting and steering forces.  
 

--- a/docs/software/openfoam.md
+++ b/docs/software/openfoam.md
@@ -2,7 +2,7 @@
 *Last update: January 27, 2025*
 
 <!-- ![OpenFOAM logo](../imgs/openfoam-logo.png){ .align-left width="75px" } -->
-<img src="../imgs/openfoam-logo.png" width="300" alt="OpenFOAM logo" align="right">
+<img src="../imgs/openfoam-logo.png" width="300" alt="OpenFOAM logo" class="align-right">
 
 The [OpenFOAM](https://www.openfoam.org) (**O**pen **F**ield **O**peration and **M**anipulation) Toolbox is a free, open source Computational Fluid Dynamics (CFD) software package providing an extensive range of features, from solving complex fluid flows involving chemical reactions, turbulence and heat transfer, to solid dynamics and electromagnetics.
 

--- a/docs/software/paraview.md
+++ b/docs/software/paraview.md
@@ -2,7 +2,7 @@
 *Last update: February 12, 2025*
 
 <!-- ![ParaView logo](../imgs/paraview-logo.svg){ .align-left } -->
-<img src="../imgs/paraview-logo.png" width="300" alt="ParaView logo" align="right">
+<img src="../imgs/paraview-logo.png" width="300" alt="ParaView logo" class="align-right">
 
 [ParaView](https://www.paraview.org/) is an open-source, multi-platform data analysis and visualization application. ParaView users can quickly build visualizations to analyze their data using qualitative and quantitative techniques. The data exploration can be done interactively in 3D or programmatically using ParaView's batch processing capabilities.
 

--- a/docs/software/quantumespresso.md
+++ b/docs/software/quantumespresso.md
@@ -2,7 +2,7 @@
 *Last update: May 15, 2024*
 
 <!-- ![Quantum Espresso logo](../imgs/qespresso-logo.png){ .align-left width="75px" } -->
-<img src="../imgs/qe-logo.png" width="300" alt="Quantum Espresso logo" align="right">
+<img src="../imgs/qe-logo.png" width="300" alt="Quantum Espresso logo" class="align-right">
 
 Quantum Espresso (QE) is an integrated suite of open-source codes for electronic-structure calculations and materials modeling at the nanoscale. Quantum Espresso (**Quantum** op<b>E</b>n-<b>S</b>ource <b>P</b>ackage for <b>R</b>esearch in <b>E</b>lectronic <b>S</b>tructure, <b>S</b>imulation, and <b>O</b>ptimization) is based on density-functional theory, plane waves, and pseudopotentials.  
 

--- a/docs/software/vasp.md
+++ b/docs/software/vasp.md
@@ -2,7 +2,7 @@
 *Last update: May 12, 2025*
 
 <!-- ![VASP logo](../imgs/vasp-logo.png){ .align-right width="200px" } -->
-<img src="../imgs/vasp-logo.png" width="300" alt="VASP logo" align="right">
+<img src="../imgs/vasp-logo.png" width="300" alt="VASP logo" class="align-right">
 
 **V**ienna **A**b initio **S**imulation **P**ackage (VASP) is a computer program for atomic scale materials modeling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles.
 


### PR DESCRIPTION
<!-- What did you change? -->

Tweaked 2cc46b9 to retain consistent styles and not use deprecated HTML.

<details>

1. `.align-right` ≠ `align="right"`
    - `.align-right` is also providing `max-width` and `margin`[^1]
2. `align="right"` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#align)`
    - we are directed to use CSS instead, hence `.align-right`

[^1]: How does `.align-right` provide more? Via [tacc-docs styles](https://github.com/TACC/TACC-Docs/blob/1e1d5b70/docs/css/extra.css#L16-L21) and [core-styles](https://github.com/TACC/Core-Styles/blob/v2.43.2/src/lib/_imports/components/align.css).

</details>

<!-- Do you want support (syntax, design, etc)? -->
Any concerns with the `margin` and `max-width` this restores?

<!-- Any reference material worth sharing? -->
(screenshots coming soon)