### PR TITLE
Aug 11 AlphaFold3 documentation update

### DIFF
--- a/docs/software/alphafold3.md
+++ b/docs/software/alphafold3.md
@@ -1,10 +1,10 @@
 # AlphaFold3 at TACC
-*Last update: May 5, 2025*
+*Last update: August 11, 2025*
 
 <!-- ![AlphaFold logo](../imgs/alphafold3-logo.png){ .align-right width="250" } -->
 <img src="../imgs/alphafold3-logo.png" width="250" alt="AlphaFold3 logo" class="align-right">
 
-AlphaFold3 is Google Deepmind's latest deep learning model for predicting the structure and interactions of biological macromolecules, including proteins, nucleic acids, small molecules, ions, and post-translational modifications. AlphaFold3 significantly expands the capabilities of AlphaFold2, offering highly accurate complex structure predictions beyond protein folding alone. In November 2024, the developers made the [source code available on Github](https://github.com/deepmind/alphafold) and published a [Nature paper](https://www.nature.com/articles/s41586-024-07487-w) ([supplementary information](https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-024-07487-w/MediaObjects/41586_2024_7487_MOESM1_ESM.pdf)) describing the method. In addition to the software, AlphaFold3 depends on ~253 GB of databases and model parameters. Researchers interested in making protein structure predictions with AlphaFold3 are encouraged to follow the guide below, and use the databases that have been prepared.
+AlphaFold3 is Google Deepmind's latest deep learning model for predicting the structure and interactions of biological macromolecules, including proteins, nucleic acids, small molecules, ions, and post-translational modifications. AlphaFold3 significantly expands the capabilities of AlphaFold2, offering highly accurate complex structure predictions beyond protein folding alone. In November 2024, the developers made the [source code available on Github](https://github.com/deepmind/alphafold) and published a [Nature paper](https://www.nature.com/articles/s41586-024-07487-w) ([supplementary information](https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-024-07487-w/MediaObjects/41586_2024_7487_MOESM1_ESM.pdf)) describing the method. In addition to the software, AlphaFold3 depends on ~250 GB of databases and model parameters. Researchers interested in making protein structure predictions with AlphaFold3 are encouraged to follow the guide below, and use the databases that have been prepared.
 
 ## Installations at TACC { #installations } 
 
@@ -18,7 +18,7 @@ AlphaFold3 is Google Deepmind's latest deep learning model for predicting the st
 HPC Resource | Versions
 -- | --
 Lonestar6 | AlphaFold3: v3.0.1<br>**Data**: `/scratch/tacc/apps/bio/alphafold3/3.0.1/data`<br>**Examples**: `/scratch/tacc/apps/bio/alphafold3/3.0.1/examples`<br> Module: `/scratch/tacc/apps/bio/alphafold3/modulefiles`
-Frontera | AlphaFold3: v3.0.1<br> *Coming soon*
+Frontera | AlphaFold3: v3.0.1<br>**Data**: `/scratch2/projects/bio/alphafold3/3.0.1/data`<br>**Examples**: `/scratch2/projects/bio/alphafold3/3.0.1/examples`<br> Module: `/scratch2/projects/bio/alphafold3/modulefiles`
 Stampede3 | AlphaFold3: v3.0.1<br> *Coming soon*
 Vista | AlphaFold3: v3.0.1<br> *Coming soon*
 
@@ -74,7 +74,7 @@ A valid protein chain may look like:
 
 ### SLURM Job Script Preparation
 
-Next, prepare a batch job submission script for running AlphaFold3. *Model inference must be run on a GPU*. See the [AlphaFold3 performance documentation](https://github.com/google-deepmind/alphafold3/blob/main/docs/performance.md) for more information on executing AlphaFold3 jobs in stages to optimize resource utilization. 
+Next, prepare a batch job submission script for running AlphaFold3. *Model inference must be run on a GPU*. See the [Running MSA and Inference Separately](#split-stages) section of this page and the [AlphaFold3 performance documentation](https://github.com/google-deepmind/alphafold3/blob/main/docs/performance.md) for more information on executing AlphaFold3 jobs in stages to optimize resource utilization. 
 
 Templates for batch job submission scripts are provided within the "Examples" paths listed in [Table 1.](#table1) above. The example templates need to be customized before they can be used. Copy the desired tample to your `$WORK` or `$SCRATCH` space along with the input `.json` file. After necessary customizations, a batch script for running AlphaFold3 on Lonestar6 may look like this:
 
@@ -91,7 +91,6 @@ Templates for batch job submission scripts are provided within the "Examples" pa
 #----------------------------------------------------------------------
 
 # Load required modules
-module unload xalt
 module use /scratch/tacc/apps/bio/alphafold3/modulefiles
 module load alphafold3/3.0.1-ctr.lua
 
@@ -100,19 +99,8 @@ export AF3_INPUT_DIR=$SCRATCH/input/
 export AF3_OUTPUT_DIR=$SCRATCH/output/
 export AF3_MODEL_PARAMETERS_DIR=$WORK/af3_parameters
 
-# Run AlphaFold3 container 
-apptainer exec \
-     --nv \
-     --bind $AF3_INPUT_DIR:/root/af_input \                             
-     --bind $AF3_OUTPUT_DIR:/root/af_output \                           
-     --bind $AF3_MODEL_PARAMETERS_DIR:/root/models \                   
-     --bind $AF3_DATABASES_DIR:/root/public_databases \     
-     $AF3_IMAGE \                                           
-     python ${AF3_CODE_DIR}/run_alphafold.py \              
-     --json_path=/root/af_input/input.json \                   # MODIFY name of input.json
-     --model_dir=/root/models \                                         
-     --db_dir=/root/public_databases \                                  
-     --output_dir=/root/af_output                                       
+# Run AlphaFold3 
+run_alphafold3 --json_path=$AF3_INPUT_DIR/input.json           # MODIFY name of input.json                                
 ```
 
 In the batch script, make sure to specify the partition (queue) (`#SBATCH -p`), node / wallclock limits, and allocation name (`#SBATCH -A`) appropriate to the machine you are running on. Also, make sure the path shown in the `module use` line matches the machine-specific "Module" path listed in [Table 1.](#table1) above.
@@ -121,14 +109,11 @@ When preparing a batch job script to run AlphaFold3, users must set several envi
 
 #### Table 2. Required Variables to Set in Job Script { #table2 }
 
-Variable | What it does | User Action Required?
+Variable | What it does | User Action Required
 -- | -- | --
-`AF3_INPUT_DIR` | Directory containing the `input.json` file | Location of your input files (e.g., `$SCRATCH/input`)
-`AF3_OUTPUT_DIR` | Directory where output will be written | Desired output path (e.g., `$SCRATCH/output`)
+`AF3_INPUT_DIR` | Directory containing the `input.json` file | Set this to the location of your input files (e.g., `$SCRATCH/input`)
+`AF3_OUTPUT_DIR` | Directory where output will be written | Set this to your desired output path (e.g., `$SCRATCH/output`)
 `AF3_MODEL_PARAMETERS_DIR` | Directory where you manually downloaded and extracted the AlphaFold3 model parameters | Set this to where you stored the models (e.g., `$WORK/af3_parameters`)
-`AF3_DATABASES_DIR` | Location of shared AlphaFold3 database files on TACC systems | **Do not modify** 
-`AF3_IMAGE` | Path to the AlphaFold3 container image | **Do not modify** 
-`AF3_CODE_DIR` | Location of AlphaFold3 source code inside the container | **Do not modify** 
 
 Once the input `.json` and customized batch script are prepared, submit to the job queue with:
 
@@ -137,6 +122,88 @@ Once the input `.json` and customized batch script are prepared, submit to the j
 e.g.:
 
 `login1$ sbatch AF3_protein.slurm`
+
+### Running MSA and Inference Separately { #split-stages }
+
+AlphaFold3 can be run in two stages:
+
+ 1. MSA stage (CPU or GPU): generates multiple sequence alignments (MSAs) from your input sequence(s).
+ 2. Inference stage (GPU): uses the MSA and other preprocessed data to generate structure predictions. 
+
+Running the stages separately allows you to run the MSA on a CPU node and run the inference step on a GPU node.
+
+#### Step 1: Run MSA
+
+A sample `protein_MSA.slurm` job script with the `--norun_inference` flag is included in the machine-specific "Examples" path listed in [Table 1.](#table1) above. After necessary customizations, a batch script for running the MSA step on Frontera may look like this:
+
+```job-script
+#!/bin/bash
+#----------------------------------------------------------------------
+#SBATCH -J protein_MSA             
+#SBATCH -o protein_MSA.o%j         
+#SBATCH -e protein_MSA.e%j        
+#SBATCH -p normal                  # Normal (CPU) queue
+#SBATCH -N 1                       
+#SBATCH -t 01:00:00                
+#SBATCH -A my-project              
+#----------------------------------------------------------------------
+
+# Load required modules
+module use /scratch2/projects/bio/alphafold3/modulefiles
+module load alphafold3/3.0.1-ctr.lua
+
+# Set environment variable definitions to point to your input, output, and model parameters directories:
+export AF3_INPUT_DIR=$SCRATCH/input/
+export AF3_OUTPUT_DIR=$SCRATCH/output/
+export AF3_MODEL_PARAMETERS_DIR=$WORK/af3_parameters
+
+# Run AlphaFold3 (MSA only)
+run_alphafold3 --json_path=$AF3_INPUT_DIR/input.json --norun_inference
+```
+
+In the batch script above:
+
+ - The partition (queue) (`#SBATCH -p`) is set to the **normal (CPU)** queue.
+ - The `--norun_inference` flag tells AlphaFold3 to stop after generating the MSA and other preprocessed data.
+ - The specified `AF3_OUTPUT_DIR` will contain all files needed for inference, including a new directory (named after the "name" value in our `input.json` file (e.g., `uqcr11_hsapiens`)) containing a new file called `uqcr11_hsapiens_data.json`. This will be our input for the inference step. 
+
+#### Step 2: Run Inference
+
+A sample `protein_inference.slurm` job script with the `--norun_data_pipeline` flag is included in the machine-specific "Examples" path listed in [Table 1.](#table1) above. After necessary customizations, a batch script for running the inference step on Frontera may look like this:
+
+```job-script
+#!/bin/bash
+#----------------------------------------------------------------------
+#SBATCH -J protein_inf             
+#SBATCH -o protein_inf.o%j         
+#SBATCH -e protein_inf.e%j        
+#SBATCH -p rtx                  # rtx queue
+#SBATCH -N 1                       
+#SBATCH -t 01:00:00                
+#SBATCH -A my-project              
+#----------------------------------------------------------------------
+
+# Load required modules
+module use /scratch2/projects/bio/alphafold3/modulefiles
+module load alphafold3/3.0.1-ctr.lua
+
+# Set environment variable definitions to point to your input, output, and model parameters directories:
+export AF3_INPUT_DIR=$SCRATCH/output/uqcr11_hsapiens
+export AF3_OUTPUT_DIR=$SCRATCH/output/uqcr11_hsapiens
+export AF3_MODEL_PARAMETERS_DIR=$WORK/af3_parameters
+
+# Run AlphaFold3 (inference only)
+run_alphafold3 --json_path=$AF3_INPUT_DIR/uqcr11_hsapiens_data.json --norun_data_pipeline
+```
+
+In the batch script above:
+
+ - The partition (queue) (`#SBATCH -p`) is set to the **rtx** queue.
+ - The `--norun_data_pipeline` flag tells AlphaFold3 to skip the MSA stage and run only the model inference. 
+
+!!! important
+    - `AF3_INPUT_DIR` must point to the new directory generated in Step 1 (e.g., `$SCRATCH/output/uqcr11_hsapiens`)
+    - `--json_path` must point to the new `_data.json` file generated by Step 1 (e.g., `uqcr11_hsapiens_data.json`)
 
 We are currently benchmarking AlphaFold3 on TACC systems. Refer to the [AlphaFold3 performance documentation](https://github.com/google-deepmind/alphafold3/blob/main/docs/performance.md#running-the-pipeline-in-stages) for runtime estimates based on token size and available hardware. Refer to the [AlphaFold3 output Documentation](https://github.com/google-deepmind/alphafold3/blob/main/docs/output.md) for a description of the expected output files. 
 


### PR DESCRIPTION
<!-- What did you change? -->
Added documentation for running AlphaFold3 on Frontera.
Additionally, edited the AlphaFold3 module files to simplify the code execution.
AlphaFold3 can now be run in stages by optionally including either the `norun_inference` or `norun_data_pipeline` flags.

<!-- Do you want support (syntax, design, etc)? -->


<!-- Any reference material worth sharing? -->
