### PR TITLE
feat: make requirements.txt

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -13,14 +13,18 @@ To make functional changes, [use extensions](https://tacc.github.io/mkdocs-tacc/
 ## How to Upgrade the Theme
 
 1. ```shell
-    poetry remove mkdocs-tacc
-    poetry add "mkdocs-tacc[all]"@latest
+    poetry add "mkdocs-tacc[all]"
     ```
 2. Verify changes in:
     - `pyproject.toml`
     - `poetry.lock`
-3. Test.
-4. Commit.
+3. ```shell
+    make requirements.txt
+    ```
+4. Verify changes in:
+    - `requirements.txt`
+5. Test.
+6. Commit.
 
 ## How to Test Your Changes
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,17 @@ DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest
 # `DOCKER_IMAGE_BRANCH` tag is the git tag for the commit if it exists, else the branch on which the commit exists
 DOCKER_IMAGE_BRANCH := $(DOCKERHUB_REPO):$(shell git describe --exact-match --tags 2> /dev/null || git symbolic-ref --short HEAD | sed 's/[^[:alnum:]\.\_\-]/-/g')
 
+
+# To regenerate requirements.txt from poetry.lock
+# CAVEAT: Using .PHONY to skip Make's dependency check
+#         of poetry.lock until it is reliable or proven useless
+.PHONY: requirements.txt
+requirements.txt: poetry.lock
+	poetry self add poetry-plugin-export \
+	&& poetry export -f requirements.txt --output requirements.txt \
+	&& poetry self remove poetry-plugin-export
+
+
 .PHONY: build
 build:
 	$(DOCKER_COMPOSE_CMD) -f ./docker-compose.yml build


### PR DESCRIPTION
## What Did You Change?

Added:
- command to create `requirements.txt`
- documentation to `make requirements.txt`

<details><summary>Why?</summary>

- DesignSafe does this automatically, but TACC does not.
- At least give maintainers a command to do it manually.
- It is common for Python projects to have one.
- It is now minimal lift to maintain one.

</details>

## Do You Want Support (syntax, design, etc)?

Nope. Tested. Ran it to create the `requirements.txt` in #171.

## Any Reference Material Worth Sharing?

Committed our first `requirements.txt` in #171.